### PR TITLE
feat(academics): filter schedule and assignments for students

### DIFF
--- a/apps/core/templates/core/partials/_nav_links.html
+++ b/apps/core/templates/core/partials/_nav_links.html
@@ -58,11 +58,6 @@
             <i class="fa-solid fa-book-open w-5 {% if 'academics/mapel' in request.path %}text-white{% else %}text-emerald-600{% endif %}"></i> Mata Pelajaran
         </a>
     </li>
-    <li>
-        <a href="{% url 'academics:jadwal_list' %}" class="rounded-xl transition-all {% if 'academics/jadwal' in request.path %}bg-gradient-to-r from-emerald-500 to-teal-600 text-white font-semibold{% else %}hover:bg-gradient-to-r hover:from-emerald-50 hover:to-teal-50{% endif %}">
-            <i class="fa-solid fa-calendar-days w-5 {% if 'academics/jadwal' in request.path %}text-white{% else %}text-emerald-600{% endif %}"></i> Jadwal Pelajaran
-        </a>
-    </li>
     {% endif %}
 
     <!-- NILAI & PRESENSI -->
@@ -70,13 +65,16 @@
     <li class="menu-title mt-6 px-3 text-xs font-bold text-gray-500 uppercase tracking-wider">
         <i class="fa-solid fa-chart-line text-emerald-600"></i> Penilaian & Kehadiran
     </li>
-    {% if not user.is_siswa %}
-        <li>
-            <a href="{% url 'grades:tugas_list' %}" class="rounded-xl transition-all {% if 'grades/tugas' in request.path %}bg-gradient-to-r from-emerald-500 to-teal-600 text-white font-semibold{% else %}hover:bg-gradient-to-r hover:from-emerald-50 hover:to-teal-50{% endif %}">
-                <i class="fa-solid fa-tasks w-5 {% if 'grades/tugas' in request.path %}text-white{% else %}text-emerald-600{% endif %}"></i> Tugas
-            </a>
-        </li>
-    {% endif %}
+    <li>
+        <a href="{% url 'academics:jadwal_list' %}" class="rounded-xl transition-all {% if 'academics/jadwal' in request.path %}bg-gradient-to-r from-emerald-500 to-teal-600 text-white font-semibold{% else %}hover:bg-gradient-to-r hover:from-emerald-50 hover:to-teal-50{% endif %}">
+            <i class="fa-solid fa-calendar-days w-5 {% if 'academics/jadwal' in request.path %}text-white{% else %}text-emerald-600{% endif %}"></i> Jadwal Pelajaran
+        </a>
+    </li>
+    <li>
+        <a href="{% url 'grades:tugas_list' %}" class="rounded-xl transition-all {% if 'grades/tugas' in request.path %}bg-gradient-to-r from-emerald-500 to-teal-600 text-white font-semibold{% else %}hover:bg-gradient-to-r hover:from-emerald-50 hover:to-teal-50{% endif %}">
+            <i class="fa-solid fa-tasks w-5 {% if 'grades/tugas' in request.path %}text-white{% else %}text-emerald-600{% endif %}"></i> Tugas
+        </a>
+    </li>
     <li>
         <a href="{% url 'grades:nilai_list' %}" class="rounded-xl transition-all {% if 'grades/nilai' in request.path %}bg-gradient-to-r from-emerald-500 to-teal-600 text-white font-semibold{% else %}hover:bg-gradient-to-r hover:from-emerald-50 hover:to-teal-50{% endif %}">
             <i class="fa-solid fa-award w-5 {% if 'grades/nilai' in request.path %}text-white{% else %}text-emerald-600{% endif %}"></i> Nilai


### PR DESCRIPTION
This change filters the schedule (Jadwal) and assignments (Tugas) lists to show only the data relevant to the logged-in student's current class.

- Modified `JadwalListView` and `TugasListView` to filter querysets based on the student's class in the active academic year.
- Updated the navigation sidebar to make the "Tugas" (Assignments) link visible to students.
- Reorganized navigation links for better logical grouping.